### PR TITLE
pyscript: Use detail property of micropython-print event

### DIFF
--- a/pyscript.js
+++ b/pyscript.js
@@ -300,7 +300,7 @@ const main = function() {
                 mp_memory = config.mp_memory;
             }
             document.addEventListener('micropython-print', function(e) {
-                Interpreter.print(e.data);
+                Interpreter.print(e.detail);
             }, false);
             let mp_js_startup = Module['onRuntimeInitialized'];
             Module["onRuntimeInitialized"] = async function() {


### PR DESCRIPTION
As per https://github.com/micropython/micropython/pull/9904
After https://github.com/micropython/micropython/pull/10064, we can print utf-8 encoded strings from MicroPython.